### PR TITLE
Use git submodules for tdlib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "td"]
+	path = td
+	url = https://github.com/tdlib/td.git
+	branch = 1fa2a372a88c26369dcac2ce476166531df74a77

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "td"]
 	path = td
 	url = https://github.com/tdlib/td.git
-	branch = 1fa2a372a88c26369dcac2ce476166531df74a77

--- a/build_and_install.sh
+++ b/build_and_install.sh
@@ -4,7 +4,7 @@ set -e
 
 JOBS="$(nproc || echo 1)"
 
-git submodule update
+git submodule update --init --recursive
 pushd td
   rm -rf build
   mkdir build

--- a/build_and_install.sh
+++ b/build_and_install.sh
@@ -4,20 +4,21 @@ set -e
 
 JOBS="$(nproc || echo 1)"
 
+git submodule update
+pushd td
+  rm -rf build
+  mkdir build
+  pushd build
+    cmake -DCMAKE_BUILD_TYPE=Release ..
+    make -j "${JOBS}"
+    make install DESTDIR=destdir
+  popd
+popd
+
 rm -rf build
 mkdir build
 pushd build
-  git clone https://github.com/tdlib/td.git
-  pushd td
-    git checkout 1fa2a372a88c26369dcac2ce476166531df74a77 # 1.8.34
-    mkdir build
-    pushd build
-      cmake -DCMAKE_BUILD_TYPE=Release ..
-      make -j "${JOBS}"
-      make install DESTDIR=destdir
-    popd
-  popd
-  cmake -DTd_DIR="$(realpath .)"/td/build/destdir/usr/local/lib/cmake/Td/ -DNoVoip=True ..
+  cmake -DTd_DIR="$(realpath ../td)"/build/destdir/usr/local/lib/cmake/Td/ -DNoVoip=True ..
   make -j "${JOBS}"
   echo "Now calling sudo make install"
   sudo make install


### PR DESCRIPTION
The [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) is a native way to use an included repo.
I made it to checkout into the `td` folder instead of `build/td` that is removed in the `build_and_install.sh` script. So now the script can be re-executed without loosing the the tdlib sources and a new checkout.